### PR TITLE
Update wp-config.php

### DIFF
--- a/examples/wordpress-vanilla/wordpress/wp-config.php
+++ b/examples/wordpress-vanilla/wordpress/wp-config.php
@@ -6,61 +6,61 @@ $site_host = 'localhost';
 
 // Update scheme and hostname for the requested page.
 if (isset($_SERVER['HTTP_HOST'])) {
-  $site_host = $_SERVER['HTTP_HOST'];
-  $site_scheme = !empty($_SERVER['HTTPS']) ? 'https' : 'http';
+    $site_host = $_SERVER['HTTP_HOST'];
+    $site_scheme = !empty($_SERVER['HTTPS']) ? 'https' : 'http';
 }
 
 if (getenv('PLATFORM_RELATIONSHIPS')) {
-	if(getenv('DB_NAME')){
+    if(getenv('DB_HOST')){
 
-		// Avoid PHP notices on CLI requests.
-		if (php_sapi_name() === 'cli') {
-			session_save_path("/tmp");
-		}
+        // Avoid PHP notices on CLI requests.
+        if (php_sapi_name() === 'cli') {
+            session_save_path("/tmp");
+        }
 
-		// We are using the first relationship called "database" found in your
-		// relationships. Note that you can call this relationship as you wish
-		// in your `.platform.app.yaml` file, but 'database' is a good name.
-		define( 'DB_NAME', getenv('DB_NAME'));
-		define( 'DB_USER', getenv('DB_USER'));
-		define( 'DB_PASSWORD', getenv('DB_PASSWORD'));
-		define( 'DB_HOST', getenv('DB_HOST'));
-		define( 'DB_CHARSET', 'utf8' );
-		define( 'DB_COLLATE', '' );
+        // We are using the first relationship called "database" found in your
+        // relationships. Note that you can call this relationship as you wish
+        // in your `.platform.app.yaml` file, but 'database' is a good name.
+        define( 'DB_NAME', getenv('DB_DATABASE'));
+        define( 'DB_USER', getenv('DB_USERNAME'));
+        define( 'DB_PASSWORD', getenv('DB_PASSWORD'));
+        define( 'DB_HOST', getenv('DB_HOST'));
+        define( 'DB_CHARSET', 'utf8' );
+        define( 'DB_COLLATE', '' );
 
-		// Debug mode should be disabled on Platform.sh. Set this constant to true
-		// in a wp-config-local.php file to skip this setting on local development.
-		if (!defined( 'WP_DEBUG' )) {
-			define( 'WP_DEBUG', false );
-		}
+        // Debug mode should be disabled on Platform.sh. Set this constant to true
+        // in a wp-config-local.php file to skip this setting on local development.
+        if (!defined( 'WP_DEBUG' )) {
+            define( 'WP_DEBUG', false );
+        }
 
-		// Set all of the necessary keys to unique values, based on the Platform.sh
-		// entropy value.
-		if (getenv('PLATFORM_PROJECT_ENTROPY')) {
-			$keys = [
-				'AUTH_KEY',
-				'SECURE_AUTH_KEY',
-				'LOGGED_IN_KEY',
-				'NONCE_KEY',
-				'AUTH_SALT',
-				'SECURE_AUTH_SALT',
-				'LOGGED_IN_SALT',
-				'NONCE_SALT',
-			];
-			$entropy = getenv('PLATFORM_PROJECT_ENTROPY');
-			foreach ($keys as $key) {
-				if (!defined($key)) {
-					define( $key, $entropy . $key );
-				}
-			}
-		}
-	}
+        // Set all of the necessary keys to unique values, based on the Platform.sh
+        // entropy value.
+        if (getenv('PLATFORM_PROJECT_ENTROPY')) {
+            $keys = [
+                'AUTH_KEY',
+                'SECURE_AUTH_KEY',
+                'LOGGED_IN_KEY',
+                'NONCE_KEY',
+                'AUTH_SALT',
+                'SECURE_AUTH_SALT',
+                'LOGGED_IN_SALT',
+                'NONCE_SALT',
+            ];
+            $entropy = getenv('PLATFORM_PROJECT_ENTROPY');
+            foreach ($keys as $key) {
+                if (!defined($key)) {
+                    define( $key, $entropy . $key );
+                }
+            }
+        }
+    }
 }
 else {
-  // Local configuration file should be in project root.
-  if (file_exists(dirname(__FILE__, 2) . '/wp-config-local.php')) {
-    include(dirname(__FILE__, 2) . '/wp-config-local.php');
-  }
+    // Local configuration file should be in project root.
+    if (file_exists(dirname(__FILE__, 2) . '/wp-config-local.php')) {
+        include(dirname(__FILE__, 2) . '/wp-config-local.php');
+    }
 }
 
 // Do not put a slash "/" at the end.
@@ -82,7 +82,7 @@ $table_prefix  = 'wp_';
 
 /** Absolute path to the WordPress directory. */
 if ( ! defined( 'ABSPATH' ) ) {
-  define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+    define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
 
 /** Sets up WordPress vars and included files. */


### PR DESCRIPTION
correct environment names to match what is generated by upsunify.

There are some small discrepancies between what upsunify generates in the `.environment` file. Instead of instructing the users to alter the generated `.environment` file, we'll update wp-config.php since we have them copy and paste it from this version anyway. 

The biggest one is `DB_USER` vs `DB_USERNAME` and `DB_NAME` vs `DB_DATABASE`. 

Last, we previously checked for the existence of `DB_NAME` in order to proceed with processing. This has been changed to `DB_HOST` since `DB_NAME` is not used by upsunify. 