### PR TITLE
install-github-asset: Add application/x-gtar

### DIFF
--- a/src/install-github-asset.sh
+++ b/src/install-github-asset.sh
@@ -83,7 +83,7 @@ download_binary() {
     # Remove asset binary
     rm -Rf "${TMP_DEST}/${TOOL_NAME}-asset"
     ;;
-  application/gzip | application/x-gzip | application/x-tar)
+  application/gzip | application/x-gzip | application/x-tar | application/x-gtar)
     tar -xzf "${TMP_DEST}/${TOOL_NAME}-asset" -C "${TMP_DEST}/"
     # Remove asset binary
     rm -Rf "${TMP_DEST}/${TOOL_NAME}-asset"


### PR DESCRIPTION
Fixing

```
          No extraction needed for application/x-gtar file
          Success
```

which results in a .tar.gz file remaining compressed